### PR TITLE
Use invariant culture

### DIFF
--- a/GTA V Script Decompiler/Program.cs
+++ b/GTA V Script Decompiler/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using System.Globalization;
 
 namespace Decompiler
 {
@@ -21,6 +22,9 @@ namespace Decompiler
 		[STAThread]
 		private static void Main(string[] args)
 		{
+			CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+			CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
 			Crossmap = new Crossmap();
 
 			ScriptFile.HashBank = new Hashes();


### PR DESCRIPTION
Cultures with comma as decimal separator result in output such as `uLocal_80 = { -1593,813f, 5221,2354f, 1,94482f };`.